### PR TITLE
fix: change populate in services, to allow for more flexible populates

### DIFF
--- a/src/controllers/admin/quiz.controller.ts
+++ b/src/controllers/admin/quiz.controller.ts
@@ -259,7 +259,14 @@ export class AdminQuizController extends Controller {
                 {
                     __v: 0,
                 },
-                ["subject", "chapter", "potentialQuestions"]
+                [
+                    { path: "subject" },
+                    { path: "chapter" },
+                    {
+                        path: "potentialQuestions",
+                        populate: [{ path: "subject" }, { path: "chapter" }],
+                    },
+                ]
             );
 
             if (!quiz) {
@@ -275,6 +282,7 @@ export class AdminQuizController extends Controller {
                 "chapter.createdAt",
                 "chapter.createdBy",
                 "chapter.lastUpdatedAt",
+                "potentialQuestions.__v",
             ]);
 
             res.composer.success(result);

--- a/src/controllers/quiz_session.controller.ts
+++ b/src/controllers/quiz_session.controller.ts
@@ -197,9 +197,22 @@ export class QuizSessionController extends Controller {
 
             if (req.query.pagination === "false") {
                 const result = (
-                    await this.quizSessionService.getExpanded({
-                        userId: userId,
-                    })
+                    await this.quizSessionService.getExpanded(
+                        {
+                            userId: userId,
+                        },
+                        {
+                            path: "fromQuiz",
+                            populate: [
+                                {
+                                    path: "subject",
+                                },
+                                {
+                                    path: "chapter",
+                                },
+                            ],
+                        }
+                    )
                 ).filter(quizSessionFilter);
 
                 const adjustedResult = result.map((quizSession) =>
@@ -216,6 +229,17 @@ export class QuizSessionController extends Controller {
                 const [total, unmappedResult] =
                     await this.quizSessionService.getPaginated(
                         { userId: userId },
+                        {
+                            path: "fromQuiz",
+                            populate: [
+                                {
+                                    path: "subject",
+                                },
+                                {
+                                    path: "chapter",
+                                },
+                            ],
+                        },
                         pageSize,
                         pageNumber
                     );
@@ -247,9 +271,19 @@ export class QuizSessionController extends Controller {
             const { userId } = req.tokenMeta;
             const quizSessionId = new Types.ObjectId(req.params.quizSessionId);
             const quizSession = await this.quizSessionService.getByIdPopulated(
-                quizSessionId
+                quizSessionId,
+                {
+                    path: "fromQuiz",
+                    populate: [
+                        {
+                            path: "subject",
+                        },
+                        {
+                            path: "chapter",
+                        },
+                    ],
+                }
             );
-            console.log(quizSession);
 
             if (!quizSession) {
                 throw new Error(`Quiz doesn't exist`);

--- a/src/services/access_level.service.ts
+++ b/src/services/access_level.service.ts
@@ -8,6 +8,7 @@ import { ServiceType } from "../types";
 import { CacheService } from "./index";
 import {
     FilterQuery,
+    PopulateOptions,
     ProjectionType,
     QueryOptions,
     Types,
@@ -247,7 +248,7 @@ export class AccessLevelService {
     async getPaginated(
         query: FilterQuery<AccessLevelDocument>,
         projection: ProjectionType<AccessLevelDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -265,14 +266,14 @@ export class AccessLevelService {
             )
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
     async getPopulated(
         query: FilterQuery<AccessLevelDocument>,
         projection: ProjectionType<AccessLevelDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await AccessLevelModel.find(
             {
@@ -280,13 +281,13 @@ export class AccessLevelService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async getByIdPopulated(
         id: Types.ObjectId,
         projection: ProjectionType<AccessLevelDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await AccessLevelModel.findOne(
             {
@@ -294,6 +295,6 @@ export class AccessLevelService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 }

--- a/src/services/chapter.service.ts
+++ b/src/services/chapter.service.ts
@@ -2,6 +2,7 @@ import { injectable } from "inversify";
 import { logger } from "../lib/logger";
 import {
     FilterQuery,
+    PopulateOptions,
     ProjectionType,
     QueryOptions,
     Types,
@@ -88,7 +89,7 @@ export class ChapterService {
     async getByIdPopulated(
         id: Types.ObjectId,
         projection: ProjectionType<ChapterDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await ChapterModel.findOne(
             {
@@ -96,13 +97,13 @@ export class ChapterService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async getPaginated(
         query: FilterQuery<ChapterDocument>,
         projection: ProjectionType<ChapterDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -120,14 +121,14 @@ export class ChapterService {
             )
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
     async getPopulated(
         query: FilterQuery<ChapterDocument>,
         projection: ProjectionType<ChapterDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await ChapterModel.find(
             {
@@ -135,6 +136,6 @@ export class ChapterService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 }

--- a/src/services/material.service.ts
+++ b/src/services/material.service.ts
@@ -3,6 +3,7 @@ import { ServiceType } from "../types";
 import { FileUploadService } from "./file-upload.service";
 import mongoose, {
     FilterQuery,
+    PopulateOptions,
     ProjectionType,
     QueryOptions,
     SaveOptions,
@@ -115,7 +116,7 @@ export class MaterialService {
     async getByIdPopulated(
         id: Types.ObjectId,
         projection: ProjectionType<MaterialDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await MaterialModel.findOne(
             {
@@ -123,13 +124,13 @@ export class MaterialService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async getPaginated(
         query: FilterQuery<MaterialDocument>,
         projection: ProjectionType<MaterialDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -147,14 +148,14 @@ export class MaterialService {
             )
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
     async getPopulated(
         query: FilterQuery<MaterialDocument>,
         projection: ProjectionType<MaterialDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await MaterialModel.find(
             {
@@ -162,7 +163,7 @@ export class MaterialService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async editOneMaterial(

--- a/src/services/previous_exam.service.ts
+++ b/src/services/previous_exam.service.ts
@@ -3,6 +3,7 @@ import { ServiceType } from "../types";
 import { FileUploadService } from "./file-upload.service";
 import mongoose, {
     FilterQuery,
+    PopulateOptions,
     ProjectionType,
     QueryOptions,
     Types,
@@ -99,7 +100,7 @@ export class PreviousExamService {
     async getByIdPopulated(
         id: Types.ObjectId,
         projection: ProjectionType<PreviousExamDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await PreviousExamModel.findOne(
             {
@@ -107,13 +108,13 @@ export class PreviousExamService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async getPaginated(
         query: FilterQuery<PreviousExamDocument>,
         projection: ProjectionType<PreviousExamDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -131,14 +132,14 @@ export class PreviousExamService {
             )
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
     async getPopulated(
         query: FilterQuery<PreviousExamDocument>,
         projection: ProjectionType<PreviousExamDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await PreviousExamModel.find(
             {
@@ -146,7 +147,7 @@ export class PreviousExamService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async editOne(

--- a/src/services/question.service.ts
+++ b/src/services/question.service.ts
@@ -1,6 +1,6 @@
 import { injectable } from "inversify";
 import { logger } from "../lib/logger";
-import { FilterQuery, QueryOptions, Types } from "mongoose";
+import { FilterQuery, PopulateOptions, QueryOptions, Types } from "mongoose";
 import QuestionModel, {
     ConcreteQuestion,
     QuestionDocument,
@@ -247,7 +247,7 @@ export class QuestionService {
 
     async getPaginated(
         query: FilterQuery<QuestionDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -262,15 +262,18 @@ export class QuestionService {
             })
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
-    async getPopulated(query: FilterQuery<QuestionDocument>, paths: string[]) {
+    async getPopulated(
+        query: FilterQuery<QuestionDocument>,
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
+    ) {
         return await QuestionModel.find({
             ...query,
             deletedAt: { $exists: false },
-        }).populate(paths);
+        }).populate(populateOptions);
     }
 
     async getById(id: Types.ObjectId) {
@@ -280,11 +283,14 @@ export class QuestionService {
         });
     }
 
-    async getByIdPopulated(id: Types.ObjectId, paths: string[]) {
+    async getByIdPopulated(
+        id: Types.ObjectId,
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
+    ) {
         return await QuestionModel.findOne({
             _id: id,
             deletedAt: { $exists: false },
-        }).populate(paths);
+        }).populate(populateOptions);
     }
 
     async questionWithSubjectExists(subjectId: Types.ObjectId) {

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -1,6 +1,7 @@
 import { injectable } from "inversify";
 import {
     FilterQuery,
+    PopulateOptions,
     ProjectionType,
     QueryOptions,
     Types,
@@ -92,7 +93,7 @@ export class QuizService {
     async getPaginated(
         query: FilterQuery<QuizDocument>,
         projection: ProjectionType<QuizDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -110,14 +111,14 @@ export class QuizService {
             )
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
     async getPopulated(
         query: FilterQuery<QuizDocument>,
         projection: ProjectionType<QuizDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await QuizModel.find(
             {
@@ -125,13 +126,13 @@ export class QuizService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 
     async getByIdPopulated(
         id: Types.ObjectId,
         projection: ProjectionType<QuizDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await QuizModel.findOne(
             {
@@ -139,6 +140,6 @@ export class QuizService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 }

--- a/src/services/quiz_session.service.ts
+++ b/src/services/quiz_session.service.ts
@@ -1,6 +1,6 @@
 import { injectable } from "inversify";
 import { logger } from "../lib/logger";
-import { FilterQuery, PipelineStage, Types } from "mongoose";
+import { FilterQuery, PipelineStage, PopulateOptions, Types } from "mongoose";
 import { ConcreteQuestion } from "../models/question.model";
 import QuizSessionModel, {
     QuizSessionDocument,
@@ -62,6 +62,7 @@ export class QuizSessionService {
 
     async getPaginated(
         query: FilterQuery<QuizSessionDocument>,
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -76,48 +77,24 @@ export class QuizSessionService {
             })
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate({
-                    path: "fromQuiz",
-                    populate: [
-                        {
-                            path: "subject",
-                        },
-                        {
-                            path: "chapter",
-                        },
-                    ],
-                }),
+                .populate(populateOptions),
         ]);
     }
 
-    async getExpanded(query: FilterQuery<QuizSessionDocument>) {
+    async getExpanded(
+        query: FilterQuery<QuizSessionDocument>,
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
+    ) {
         return await QuizSessionModel.find({
             ...query,
             deletedAt: { $exists: false },
-        }).populate({
-            path: "fromQuiz",
-            populate: [
-                {
-                    path: "subject",
-                },
-                {
-                    path: "chapter",
-                },
-            ],
-        });
+        }).populate(populateOptions);
     }
 
-    async getByIdPopulated(id: Types.ObjectId) {
-        return await QuizSessionModel.findById(id).populate({
-            path: "fromQuiz",
-            populate: [
-                {
-                    path: "subject",
-                },
-                {
-                    path: "chapter",
-                },
-            ],
-        });
+    async getByIdPopulated(
+        id: Types.ObjectId,
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
+    ) {
+        return await QuizSessionModel.findById(id).populate(populateOptions);
     }
 }

--- a/src/services/subject.service.ts
+++ b/src/services/subject.service.ts
@@ -2,6 +2,7 @@ import { injectable } from "inversify";
 import SubjectModel, { SubjectDocument } from "../models/subject.model";
 import {
     FilterQuery,
+    PopulateOptions,
     ProjectionType,
     QueryOptions,
     Types,
@@ -82,7 +83,7 @@ export class SubjectService {
     async getPaginated(
         query: FilterQuery<SubjectDocument>,
         projection: ProjectionType<SubjectDocument>,
-        paths: string[],
+        populateOptions: PopulateOptions | (string | PopulateOptions)[],
         pageSize: number,
         pageNumber: number
     ) {
@@ -100,14 +101,14 @@ export class SubjectService {
             )
                 .skip(Math.max(pageSize * (pageNumber - 1), 0))
                 .limit(pageSize)
-                .populate(paths),
+                .populate(populateOptions),
         ]);
     }
 
     async getPopulated(
         query: FilterQuery<SubjectDocument>,
         projection: ProjectionType<SubjectDocument>,
-        paths: string[]
+        populateOptions: PopulateOptions | (string | PopulateOptions)[]
     ) {
         return await SubjectModel.find(
             {
@@ -115,6 +116,6 @@ export class SubjectService {
                 deletedAt: { $exists: false },
             },
             projection
-        ).populate(paths);
+        ).populate(populateOptions);
     }
 }


### PR DESCRIPTION
- Refactor 'populate' calls in services, to allow for more flexibility
- Populate 'potentialQuestion.subject' and 'potentialQuestions.chapter' when querying by id