### PR TITLE
Change how exam is masked for user route + prohibit exams with same subject, semester and type

### DIFF
--- a/src/controllers/exam.controller.ts
+++ b/src/controllers/exam.controller.ts
@@ -158,7 +158,7 @@ export class ExamController implements Controller {
             exam.markModified("slots");
             await exam.save();
 
-            const result = this.examService.maskExam(exam, userId);
+            const result = this.examService.maskExam(exam);
             res.composer.success(result);
         } catch (error) {
             logger.error(error.message);
@@ -204,7 +204,7 @@ export class ExamController implements Controller {
             exam.markModified("slots");
             await exam.save();
 
-            const result = this.examService.maskExam(exam, userId);
+            const result = this.examService.maskExam(exam);
             res.composer.success(result);
         } catch (error) {
             logger.error(error.message);
@@ -241,7 +241,7 @@ export class ExamController implements Controller {
                 throw new Error(`Exam not found`);
             }
 
-            const result = this.examService.maskExam(exam, userId);
+            const result = this.examService.maskExam(exam);
             res.composer.success(result);
         } catch (error) {
             logger.error(error.message);
@@ -303,7 +303,7 @@ export class ExamController implements Controller {
                     pageNumber
                 );
                 const maskedResult = _.map(result, (exam) =>
-                    this.examService.maskExam(exam, userId)
+                    this.examService.maskExam(exam)
                 );
                 res.composer.success({
                     total,
@@ -320,7 +320,7 @@ export class ExamController implements Controller {
                     [{ path: "subject", select: "_id name" }]
                 );
                 const maskedResult = _.map(result, (exam) =>
-                    this.examService.maskExam(exam, userId)
+                    this.examService.maskExam(exam)
                 );
                 res.composer.success({
                     total: result.length,

--- a/src/lib/dto/edit_exam.dto.ts
+++ b/src/lib/dto/edit_exam.dto.ts
@@ -14,10 +14,6 @@ export type EditExamDto = {
     name?: string;
     description?: string;
 
-    subject?: Types.ObjectId;
-    semester?: Semester;
-    type?: ExamType;
-
     registrationStartedAt?: number;
     registrationEndedAt?: number;
 


### PR DESCRIPTION
- exam.slots[].registeredUsers now shows ID of every user, instead of only the API caller
- Creating multiple exams with same subject, semester and type is now prohibited
- editing an exam's subject, semester and type is no longer allowed