### PR TITLE
Fix/event flow

### DIFF
--- a/src/controllers/admin/event.controller.ts
+++ b/src/controllers/admin/event.controller.ts
@@ -115,10 +115,6 @@ export class AdminEventController implements Controller {
                 throw new Error("Event name is required");
             }
 
-            if (_.isEmpty(eventInfo.description)) {
-                throw new Error("Event description is required");
-            }
-
             if (!Object.values(EventType).includes(eventInfo.eventType)) {
                 throw new Error(`Invalid event type: ${eventInfo.eventType}`);
             }
@@ -250,10 +246,6 @@ export class AdminEventController implements Controller {
             // check validity of eventInfo
             if (_.isEmpty(info.name)) {
                 throw new Error("Event name is required");
-            }
-
-            if (_.isEmpty(info.description)) {
-                throw new Error("Event description is required");
             }
 
             if (!Object.values(EventType).includes(info.eventType)) {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -108,7 +108,7 @@ export class EventController implements Controller {
                     canRegister = false;
                 }
             } else {
-                if (now > event.startedAt) {
+                if (now > event.endedAt) {
                     canRegister = false;
                 }
             }

--- a/src/models/event.model.ts
+++ b/src/models/event.model.ts
@@ -12,7 +12,7 @@ export enum EventType {
 
 export type EventDocument = Document & {
     name: string;
-    description: string;
+    description?: string;
 
     eventType: EventType;
     venue: string;


### PR DESCRIPTION
I have change some of the conditions used for event creation, event patch and event registration:
- For event creation and event updates: requirement for event's description is removed entirely.
- For event registration flow: the user can now register and check-in for the event/activities before the event end (if the event has fixed registration time frame, the user still has to follow the given time frame for registration).